### PR TITLE
Usage function for command line

### DIFF
--- a/polybar-timer.sh
+++ b/polybar-timer.sh
@@ -60,10 +60,12 @@ Script usage: $0 [COMMAND] args ...
 
 COMMAND:
   new [m] [rLabel] [pLabel] [action]    - Create a new timer with [m] minutes. Printed as "[rLabel|pLabel] [m]".
-                                         [rLabel] is shown while the timer is running, and [pLabel] is shown while the timer is paused.
-                                         The action will be executed when the timer expires.
-  tail [label] [s]                      - Print the time left on the timer, followed by the [label], every [s] seconds.
-  update [pid]                          - Update a running [tail] command identified by its process id [pid].
+                                          [rLabel] is shown while the timer is running, and [pLabel] is shown while the timer is paused.
+                                          The action will be executed when the timer expires.
+  tail [label] [s]                      - Print the [label], followed by the time left on the timer, every [s] seconds.
+                                          This may be used for the exec field in polybar.
+  update [pid]                          - Update a running [tail] command identified by its PID [pid].
+                                          The PID is provided by polybar with %pid%.
   increase [s]                          - Increase the timer by [s] seconds if it exists.
   togglepause                           - Pause a running timer; Start a paused timer.
   cancel                                - Abort a timer if it exists.

--- a/polybar-timer.sh
+++ b/polybar-timer.sh
@@ -68,7 +68,7 @@ COMMAND:
                                           The PID is provided by polybar with %pid%.
   increase [s]                          - Increase the timer by [s] seconds if it exists.
   togglepause                           - Pause a running timer; Start a paused timer.
-  cancel                                - Abort a timer if it exists.
+  cancel                                - Cancel a timer if it exists.
   help                                  - Print this help.
 
 EOF

--- a/polybar-timer.sh
+++ b/polybar-timer.sh
@@ -51,6 +51,27 @@ updateTail () {
   fi
 }
 
+usage() {
+    cat <<EOF
+A script to create, start, and control a timer.
+Designed for use within polybar. Check out https://github.com/jbirnick/polybar-timer#example-configuration for an example.
+
+Script usage: $0 [COMMAND] args ...
+
+COMMAND:
+  new [m] [rLabel] [pLabel] [action]    - Create a new timer with [m] minutes. Printed as "[rLabel|pLabel] [m]".
+                                         [rLabel] is shown while the timer is running, and [pLabel] is shown while the timer is paused.
+                                         The action will be executed when the timer expires.
+  tail [label] [s]                      - Print the time left on the timer, followed by the [label], every [s] seconds.
+  update [pid]                          - Update a running [tail] command identified by its process id [pid].
+  increase [s]                          - Increase the timer by [s] seconds if it exists.
+  togglepause                           - Pause a running timer; Start a paused timer.
+  cancel                                - Abort a timer if it exists.
+  help                                  - Print this help.
+
+EOF
+}
+
 ## MAIN CODE
 
 case $1 in
@@ -113,7 +134,11 @@ case $1 in
       exit 1
     fi
     ;;
+  help|-h|--help)
+    usage
+    ;;
   *)
+    echo -e "For usage type: $0 help\n"
     echo "Please read the manual at https://github.com/jbirnick/polybar-timer ."
     ;;
 esac


### PR DESCRIPTION
This pull request adds a 'help' or usage function to the script. The help function can be invoked using 'help', '-h', or '--help' as arguments for the script.

The help function provides a brief description and synopsis, followed by a more in-depth explanation of the available commands. To enhance readability and ease of editing, the cat command is used to format the output.

Additionally, if no argument is provided when executing the script, it now informs the user to use the help function. This improvement aims to guide users to access helpful information, complementing the existing manual reference.

Please review and merge as appropriate.


