### PR TITLE
fix eval errors

### DIFF
--- a/polybar-timer.sh
+++ b/polybar-timer.sh
@@ -31,7 +31,7 @@ updateTail () {
   then
     if { timerPaused && [ $(minutesLeftWhenPaused) -le 0 ] ; } || { ! timerPaused && [ $(minutesLeft) -le 0 ] ; }
     then
-      eval $(timerAction)
+      eval $(timerAction) 2>/dev/null 1>/dev/null
       killTimer
       removePrinting
     fi


### PR DESCRIPTION
if we don't redirect the output, we'll get random text with errors  when the timer is manually decreased from from 1 to 0.
I managed to reproduce the issue almost every time with mouse wheel